### PR TITLE
Install presets at runtime

### DIFF
--- a/installer/CMakeLists.txt
+++ b/installer/CMakeLists.txt
@@ -84,7 +84,7 @@ else ()
 endif ()
 
 # codec specific component install paths
-set(CPACK_NSIS_Presets_INSTALL_DIRECTORY "$PROFILE\\\\Documents\\\\Adobe\\\\Adobe\ Media\ Encoder\\\\13.0")
+set(CPACK_NSIS_Presets_INSTALL_DIRECTORY "$PROGRAMFILES64\\\\Adobe\\\\Common\\\\Plug-ins\\\\7.0\\\\MediaCore\\\\${Foundation_CODEC_NAME}")
 
 # generic installer framework
 # This must always be after CPACK settings

--- a/source/plugin/premiere/CMakeLists.txt
+++ b/source/plugin/premiere/CMakeLists.txt
@@ -90,7 +90,13 @@ if (APPLE)
                     PROPERTY COMPILE_DEFINITIONS FOUNDATION_MACOSX_BUNDLE_GUI_IDENTIFIER=@\"${Foundation_IDENTIFIER_PREFIX}.pr\"
     )
 endif (APPLE)
-
+if (MSVC)
+    # used so we can look up install location from code
+    set_property(SOURCE presets.cpp
+                    APPEND
+                    PROPERTY COMPILE_DEFINITIONS FOUNDATION_CODEC_NAME=\"${Foundation_CODEC_NAME}\"
+    )
+endif (MSVC)
 install(
   TARGETS PremierePlugin
   RUNTIME

--- a/source/plugin/premiere/CMakeLists.txt
+++ b/source/plugin/premiere/CMakeLists.txt
@@ -21,7 +21,12 @@ target_sources(PremierePlugin
         prstring.cpp
         prstring.hpp
         targetver.h
+        presets.hpp
+        $<$<PLATFORM_ID:Windows>:presets.cpp>
+        $<$<PLATFORM_ID:Darwin>:presets.mm>
 )
+
+find_library(Foundation Foundation)
 
 target_link_libraries(PremierePlugin
     PRIVATE
@@ -30,6 +35,7 @@ target_link_libraries(PremierePlugin
         CodecFoundationSession
         AdobePremiereSdk
         AdobeShared
+        $<$<PLATFORM_ID:Darwin>:${Foundation}>
 )
 
 if (MSVC)
@@ -76,6 +82,14 @@ set_target_properties(PremierePlugin
 	    BUNDLE TRUE
 	    MACOSX_BUNDLE_GUI_IDENTIFIER ${Foundation_IDENTIFIER_PREFIX}.pr
 )
+
+if (APPLE)
+    # used so we can look up bundle location from code
+    set_property(SOURCE presets.mm
+                    APPEND
+                    PROPERTY COMPILE_DEFINITIONS FOUNDATION_MACOSX_BUNDLE_GUI_IDENTIFIER=@\"${Foundation_IDENTIFIER_PREFIX}.pr\"
+    )
+endif (APPLE)
 
 install(
   TARGETS PremierePlugin

--- a/source/plugin/premiere/main.cpp
+++ b/source/plugin/premiere/main.cpp
@@ -6,6 +6,7 @@
 #include "exporter.hpp"
 #include "configure.hpp"
 #include "string_conversion.hpp"
+#include "presets.hpp"
 #include <vector>
 #include <locale>
 
@@ -76,10 +77,29 @@ DllExport PREMPLUGENTRY xSDKExport(csSDK_int32 selector, exportStdParms* stdParm
 	return result;
 }
 
+static void checkPresetsInstalled()
+{
+    /*
+     Check for up(or down)graded versions of CC missing presets
+     */
+    auto src_dir = Presets::getSourceDirectoryPath();
+    auto presets = Presets::getPresetFileNames();
+    auto dsts = Presets::getDestinationDirectoryPaths();
+    for (const auto &destination : dsts)
+    {
+        for (const auto &preset : presets)
+        {
+            Presets::copy(preset, src_dir, destination, false);
+        }
+    }
+}
+
 prMALError startup(exportStdParms* stdParms, exExporterInfoRec* infoRec)
 {
     if (infoRec->exportReqIndex == 0)
     {
+        checkPresetsInstalled();
+
         // singleton needed from here on
         const auto &codec = *CodecRegistry::codec();
 

--- a/source/plugin/premiere/main.cpp
+++ b/source/plugin/premiere/main.cpp
@@ -80,16 +80,35 @@ DllExport PREMPLUGENTRY xSDKExport(csSDK_int32 selector, exportStdParms* stdParm
 static void checkPresetsInstalled()
 {
     /*
-     Check for up(or down)graded versions of CC missing presets
+     Because presets have a new install location for every major CC version, but plugins
+     are in a fixed location, it is possible for the plugin to be loaded without presets
+     when a new version of CC is installed.
+
+     Check for up(or down)graded versions of CC without presets, and install them
      */
-    auto src_dir = Presets::getSourceDirectoryPath();
     auto presets = Presets::getPresetFileNames();
+    // Do nothing if we have no presets at the plugin install location
+    if (presets.empty())
+    {
+        return;
+    }
+    auto src_dir = Presets::getSourceDirectoryPath();
     auto dsts = Presets::getDestinationDirectoryPaths();
     for (const auto &destination : dsts)
     {
-        for (const auto &preset : presets)
+        // Create the Presets directory if needed
+        bool exists = Presets::directoryExists(destination);
+        if (!exists)
         {
-            Presets::copy(preset, src_dir, destination, false);
+            exists = Presets::createDirectory(destination);
+        }
+        if (exists)
+        {
+            // Install the presets if not already present
+            for (const auto &preset : presets)
+            {
+                Presets::copy(preset, src_dir, destination, false);
+            }
         }
     }
 }

--- a/source/plugin/premiere/presets.cpp
+++ b/source/plugin/premiere/presets.cpp
@@ -74,8 +74,8 @@ bool Presets::directoryExists(const Presets::PathType &directory)
     {
         return false;
     }
-    // TODO: 
-    return false;
+	std::error_code error;
+	return std::filesystem::exists(directory, error) && std::filesystem::is_directory(directory, error);
 }
 
 bool Presets::createDirectory(const Presets::PathType &directory)
@@ -84,8 +84,8 @@ bool Presets::createDirectory(const Presets::PathType &directory)
     {
         return false;
     }
-    // TODO: 
-    return false;
+	std::error_code error;
+	return std::filesystem::create_directory(directory, error);
 }
 
 void Presets::copy(const Presets::PathType& file, const Presets::PathType& source_dir, const Presets::PathType& destination_dir, bool replace)
@@ -99,8 +99,6 @@ void Presets::copy(const Presets::PathType& file, const Presets::PathType& sourc
 	std::error_code error;
 	if (replace || !std::filesystem::exists(dest, error))
 	{
-		// Create directory if it doesn't already exist
-		std::filesystem::create_directories(destination_dir, error);
 		// Copy the file
 		std::filesystem::copy_file(src, dest, replace ? std::filesystem::copy_options::overwrite_existing : std::filesystem::copy_options::none, error);
 		// Ignoring error for now

--- a/source/plugin/premiere/presets.cpp
+++ b/source/plugin/premiere/presets.cpp
@@ -1,33 +1,88 @@
 #include "presets.hpp"
+#include <ShlObj.h>
+#include <filesystem>
 
-#include "presets.hpp"
-#include <Foundation/Foundation.h>
-
-std::vector<std::string> Presets::getDestinationDirectoryPaths()
+std::vector<Presets::PathType> Presets::getDestinationDirectoryPaths()
 {
-    std::vector<std::string> paths;
-    // TODO: 
+    std::vector<PathType> paths;
+    /*
+	Although Adobe SDK documentation suggests consulting registry keys for this,
+	the information seems to be out of date.
+	*/
+
+	PWSTR documents;
+	HRESULT hr = SHGetKnownFolderPath(FOLDERID_Documents, 0, NULL, &documents);
+	if (SUCCEEDED(hr))
+	{
+		std::filesystem::path ame(documents);
+		ame = ame / "Adobe" / "Adobe Media Encoder";
+		std::error_code error;
+		if (std::filesystem::exists(ame, error) && std::filesystem::is_directory(ame, error))
+		{
+			for (const auto& entry : std::filesystem::directory_iterator(ame, error))
+			{
+				if (entry.is_directory(error))
+				{
+					const auto path = entry.path() / "Presets";
+					paths.push_back(path);
+				}
+			}
+		}
+		CoTaskMemFree(documents);
+	}
+
     return paths;
 }
 
-std::string Presets::getSourceDirectoryPath()
+Presets::PathType Presets::getSourceDirectoryPath()
 {
-    // TODO:
-    return std::string();
+	std::filesystem::path path;
+	PWSTR programs;
+	HRESULT hr = SHGetKnownFolderPath(FOLDERID_ProgramFilesX64, 0, NULL, &programs);
+	if (SUCCEEDED(hr))
+	{
+		path = programs;
+		path = path / "Adobe" / "Common" / "Plug-Ins" / "7.0" / "MediaCore";
+		path /= FOUNDATION_CODEC_NAME;
+		path /= "Presets";
+		CoTaskMemFree(programs);
+	}
+    return path;
 }
 
-std::vector<std::string> Presets::getPresetFileNames()
+std::vector<Presets::PathType> Presets::getPresetFileNames()
 {
-    std::vector<std::string> names;
-    // TODO: 
+    std::vector<Presets::PathType> names;
+	const auto& source = getSourceDirectoryPath();
+	std::error_code error;
+	if (std::filesystem::exists(source, error) && std::filesystem::is_directory(source, error))
+	{
+		for (const auto& entry : std::filesystem::directory_iterator(source, error))
+		{
+			if (entry.is_regular_file(error) && entry.path().extension() == ".epr")
+			{
+				names.push_back(entry.path().filename());
+			}
+		}
+	}
     return names;
 }
 
-void Presets::copy(const std::string &file, const std::string &source_dir, const std::string &destination_dir, bool replace)
+void Presets::copy(const Presets::PathType& file, const Presets::PathType& source_dir, const Presets::PathType& destination_dir, bool replace)
 {
-    if (source_dir.empty() || destination_dir.empty() || file.empty())
-    {
-        return;
-    }
-    // TODO: 
+	if (source_dir.empty() || destination_dir.empty() || file.empty())
+	{
+		return;
+	}
+	const auto& dest = destination_dir / file;
+	const auto& src = source_dir / file;
+	std::error_code error;
+	if (replace || !std::filesystem::exists(dest, error))
+	{
+		// Create directory if it doesn't already exist
+		std::filesystem::create_directories(destination_dir, error);
+		// Copy the file
+		std::filesystem::copy_file(src, dest, replace ? std::filesystem::copy_options::overwrite_existing : std::filesystem::copy_options::none, error);
+		// Ignoring error for now
+	}
 }

--- a/source/plugin/premiere/presets.cpp
+++ b/source/plugin/premiere/presets.cpp
@@ -68,6 +68,26 @@ std::vector<Presets::PathType> Presets::getPresetFileNames()
     return names;
 }
 
+bool Presets::directoryExists(const Presets::PathType &directory)
+{
+    if (directory.empty())
+    {
+        return false;
+    }
+    // TODO: 
+    return false;
+}
+
+bool Presets::createDirectory(const Presets::PathType &directory)
+{
+    if (directory.empty())
+    {
+        return false;
+    }
+    // TODO: 
+    return false;
+}
+
 void Presets::copy(const Presets::PathType& file, const Presets::PathType& source_dir, const Presets::PathType& destination_dir, bool replace)
 {
 	if (source_dir.empty() || destination_dir.empty() || file.empty())

--- a/source/plugin/premiere/presets.cpp
+++ b/source/plugin/premiere/presets.cpp
@@ -1,0 +1,33 @@
+#include "presets.hpp"
+
+#include "presets.hpp"
+#include <Foundation/Foundation.h>
+
+std::vector<std::string> Presets::getDestinationDirectoryPaths()
+{
+    std::vector<std::string> paths;
+    // TODO: 
+    return paths;
+}
+
+std::string Presets::getSourceDirectoryPath()
+{
+    // TODO:
+    return std::string();
+}
+
+std::vector<std::string> Presets::getPresetFileNames()
+{
+    std::vector<std::string> names;
+    // TODO: 
+    return names;
+}
+
+void Presets::copy(const std::string &file, const std::string &source_dir, const std::string &destination_dir, bool replace)
+{
+    if (source_dir.empty() || destination_dir.empty() || file.empty())
+    {
+        return;
+    }
+    // TODO: 
+}

--- a/source/plugin/premiere/presets.hpp
+++ b/source/plugin/premiere/presets.hpp
@@ -15,5 +15,7 @@ namespace Presets {
     std::vector<PathType> getDestinationDirectoryPaths();
     PathType getSourceDirectoryPath();
     std::vector<PathType> getPresetFileNames();
+    bool directoryExists(const PathType &directory);
+    bool createDirectory(const PathType &directory);
     void copy(const PathType &file, const PathType &source_dir, const PathType &destination_dir, bool replace);
 }

--- a/source/plugin/premiere/presets.hpp
+++ b/source/plugin/premiere/presets.hpp
@@ -1,10 +1,19 @@
 #pragma once
 #include <vector>
 #include <string>
+#ifdef WIN32
+// <filesystem> not available on macOS < 10.15
+#include <filesystem>
+#endif
 
 namespace Presets {
-    std::vector<std::string> getDestinationDirectoryPaths();
-    std::string getSourceDirectoryPath();
-    std::vector<std::string> getPresetFileNames();
-    void copy(const std::string &file, const std::string &source_dir, const std::string &destination_dir, bool replace);
+#ifdef WIN32
+	using PathType = std::filesystem::path;
+#else
+	using PathType = std::string;
+#endif
+    std::vector<PathType> getDestinationDirectoryPaths();
+    PathType getSourceDirectoryPath();
+    std::vector<PathType> getPresetFileNames();
+    void copy(const PathType &file, const PathType &source_dir, const PathType &destination_dir, bool replace);
 }

--- a/source/plugin/premiere/presets.hpp
+++ b/source/plugin/premiere/presets.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <vector>
+#include <string>
+
+namespace Presets {
+    std::vector<std::string> getDestinationDirectoryPaths();
+    std::string getSourceDirectoryPath();
+    std::vector<std::string> getPresetFileNames();
+    void copy(const std::string &file, const std::string &source_dir, const std::string &destination_dir, bool replace);
+}

--- a/source/plugin/premiere/presets.mm
+++ b/source/plugin/premiere/presets.mm
@@ -1,9 +1,9 @@
 #include "presets.hpp"
 #include <Foundation/Foundation.h>
 
-std::vector<std::string> Presets::getDestinationDirectoryPaths()
+std::vector<Presets::PathType> Presets::getDestinationDirectoryPaths()
 {
-    std::vector<std::string> paths;
+    std::vector<PathType> paths;
     @autoreleasepool {
         NSArray *urls = [[NSFileManager defaultManager] URLsForDirectory:NSLibraryDirectory inDomains:NSLocalDomainMask];
         for (NSURL *url in urls)
@@ -37,16 +37,16 @@ static NSURL *getSourceDirectoryURL()
     return [bundle URLForResource:@"Presets" withExtension:nil];
 }
 
-std::string Presets::getSourceDirectoryPath()
+Presets::PathType Presets::getSourceDirectoryPath()
 {
     @autoreleasepool {
         return [[getSourceDirectoryURL() path] cStringUsingEncoding:NSUTF8StringEncoding];
     }
 }
 
-std::vector<std::string> Presets::getPresetFileNames()
+std::vector<Presets::PathType> Presets::getPresetFileNames()
 {
-    std::vector<std::string> names;
+    std::vector<Presets::PathType> names;
     @autoreleasepool {
         NSURL *source = getSourceDirectoryURL();
         if (source)
@@ -64,7 +64,7 @@ std::vector<std::string> Presets::getPresetFileNames()
     return names;
 }
 
-void Presets::copy(const std::string &file, const std::string &source_dir, const std::string &destination_dir, bool replace)
+void Presets::copy(const Presets::PathType &file, const Presets::PathType &source_dir, const Presets::PathType &destination_dir, bool replace)
 {
     if (source_dir.empty() || destination_dir.empty() || file.empty())
     {

--- a/source/plugin/premiere/presets.mm
+++ b/source/plugin/premiere/presets.mm
@@ -1,0 +1,89 @@
+#include "presets.hpp"
+#include <Foundation/Foundation.h>
+
+std::vector<std::string> Presets::getDestinationDirectoryPaths()
+{
+    std::vector<std::string> paths;
+    @autoreleasepool {
+        NSArray *urls = [[NSFileManager defaultManager] URLsForDirectory:NSLibraryDirectory inDomains:NSLocalDomainMask];
+        for (NSURL *url in urls)
+        {
+            NSURL *prefs = [url URLByAppendingPathComponent:@"Preferences" isDirectory:YES];
+            prefs = [prefs URLByAppendingPathComponent:@"com.Adobe.Premiere Pro.paths.plist" isDirectory:NO];
+            NSDictionary<NSString *, id> *dict = [NSDictionary dictionaryWithContentsOfURL:prefs];
+            if ([dict isKindOfClass:[NSDictionary class]])
+            {
+                for (NSString *key in dict)
+                {
+                    NSDictionary *version = dict[key];
+                    if ([version isKindOfClass:[NSDictionary class]])
+                    {
+                        NSString *path = version[@"CommonExporterPresetsPath"];
+                        if ([path isKindOfClass:[NSString class]])
+                        {
+                            paths.push_back([[path stringByExpandingTildeInPath] cStringUsingEncoding:NSUTF8StringEncoding]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return paths;
+}
+
+static NSURL *getSourceDirectoryURL()
+{
+    NSBundle *bundle = [NSBundle bundleWithIdentifier:FOUNDATION_MACOSX_BUNDLE_GUI_IDENTIFIER];
+    return [bundle URLForResource:@"Presets" withExtension:nil];
+}
+
+std::string Presets::getSourceDirectoryPath()
+{
+    @autoreleasepool {
+        return [[getSourceDirectoryURL() path] cStringUsingEncoding:NSUTF8StringEncoding];
+    }
+}
+
+std::vector<std::string> Presets::getPresetFileNames()
+{
+    std::vector<std::string> names;
+    @autoreleasepool {
+        NSURL *source = getSourceDirectoryURL();
+        if (source)
+        {
+            NSArray<NSURL *> *contents = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:source includingPropertiesForKeys:nil options:NSDirectoryEnumerationSkipsHiddenFiles error:nil];
+            for (NSURL *url in contents)
+            {
+                if ([[url pathExtension] isEqualToString:@"epr"])
+                {
+                    names.push_back([[url lastPathComponent] cStringUsingEncoding:NSUTF8StringEncoding]);
+                }
+            }
+        }
+    }
+    return names;
+}
+
+void Presets::copy(const std::string &file, const std::string &source_dir, const std::string &destination_dir, bool replace)
+{
+    if (source_dir.empty() || destination_dir.empty() || file.empty())
+    {
+        return;
+    }
+    @autoreleasepool {
+        NSURL *source = [NSURL fileURLWithPath:[NSString stringWithUTF8String:source_dir.c_str()] isDirectory:YES];
+        source = [source URLByAppendingPathComponent:[NSString stringWithUTF8String:file.c_str()]];
+        NSURL *dst = [NSURL fileURLWithPath:[NSString stringWithUTF8String:destination_dir.c_str()] isDirectory:YES];
+        dst = [dst URLByAppendingPathComponent:[NSString stringWithUTF8String:file.c_str()]];
+        BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:[dst path]];
+        if (replace && exists)
+        {
+            exists = ![[NSFileManager defaultManager] removeItemAtURL:dst error:nil];
+        }
+        if (!exists)
+        {
+            // Ignoring result of this for now
+            [[NSFileManager defaultManager] copyItemAtURL:source toURL:dst error:nil];
+        }
+    }
+}

--- a/source/plugin/premiere/presets.mm
+++ b/source/plugin/premiere/presets.mm
@@ -74,12 +74,24 @@ void Presets::copy(const Presets::PathType &file, const Presets::PathType &sourc
         NSURL *source = [NSURL fileURLWithPath:[NSString stringWithUTF8String:source_dir.c_str()] isDirectory:YES];
         source = [source URLByAppendingPathComponent:[NSString stringWithUTF8String:file.c_str()]];
         NSURL *dst = [NSURL fileURLWithPath:[NSString stringWithUTF8String:destination_dir.c_str()] isDirectory:YES];
-        dst = [dst URLByAppendingPathComponent:[NSString stringWithUTF8String:file.c_str()]];
+        // Create the directory if it doesn't already exist
         BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:[dst path]];
-        if (replace && exists)
+        if (!exists)
         {
-            exists = ![[NSFileManager defaultManager] removeItemAtURL:dst error:nil];
+            exists = [[NSFileManager defaultManager] createDirectoryAtURL:dst withIntermediateDirectories:NO attributes:nil error:nil];
         }
+        // If the directory exists (or we successfully created it)
+        if (exists)
+        {
+            dst = [dst URLByAppendingPathComponent:[NSString stringWithUTF8String:file.c_str()]];
+            exists = [[NSFileManager defaultManager] fileExistsAtPath:[dst path]];
+            // If the file exists and we are to replace it, delete it
+            if (replace && exists)
+            {
+                exists = ![[NSFileManager defaultManager] removeItemAtURL:dst error:nil];
+            }
+        }
+        // If the file does not exist
         if (!exists)
         {
             // Ignoring result of this for now


### PR DESCRIPTION
Because presets have a new install location for every major CC version, but plugins are in a fixed location, it is possible for the plugin to be loaded without presets when a new version of CC is installed.

This change adds a runtime check as the very first thing the Premiere plugin does, so presets are installed at runtime from a fixed location.

At *installation*:
On macOS, presets are installed as part of the Premiere plugin's Resources folder within the plugin bundle.
They are also installed by a postinstall script to some fixed known current CC locations.
On Windows, presets are installed to the codec's directory in the MediaCore folder.

On *running*:
Presets are installed for all discovered CC installations.