### PR TITLE
Configuration and logging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "external/json"]
 	path = external/json
 	url = https://github.com/nlohmann/json.git
+[submodule "external/StackWalker"]
+	path = external/StackWalker
+	url = https://github.com/JochenKalmbach/StackWalker

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
 endif()
 
 # library dependencies
-add_subdirectory(external)
+# !!! already included - add_subdirectory(external)
 
 # documentation
 # add_subdirectory(doc)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_subdirectory(adobe)
 add_subdirectory(ffmpeg)
 
+if (WIN32)
+    add_subdirectory(StackWalker)
+endif ()
+
 set(JSON_BuildTests OFF CACHE INTERNAL "")
 add_subdirectory(json)

--- a/license.txt
+++ b/license.txt
@@ -705,3 +705,33 @@ whether future versions of the GNU Lesser General Public License shall
 apply, that proxy's public statement of acceptance of any version is
 permanent authorization for you to choose that version for the
 Library.
+
+
+
+StackWalker - https://github.com/JochenKalmbach/StackWalker
+
+BSD-2-Clause
+
+Copyright (c) 2005 - 2019, Jochen Kalmbach
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/source/codec_registration/CMakeLists.txt
+++ b/source/codec_registration/CMakeLists.txt
@@ -3,15 +3,24 @@ project(CodecRegistration)
 
 set (CMAKE_CXX_STANDARD 17)
 
+# !!! We are dependent on this so the configuration file location gets compiled in
+# !!! ideally the hosting environment would pass in this information
+add_definitions(-DFOUNDATION_CODEC_NAME=\"${Foundation_CODEC_NAME}\")
+
 # this is the one we will install
 add_library(CodecRegistration
-    ${CMAKE_CURRENT_LIST_DIR}/util.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/util.hpp
+    codec_registration.hpp
+    config.cpp
+    config.hpp
+    logging.cpp
+    logging.hpp
+    util.cpp
+    util.hpp
 )
 
-target_sources(CodecRegistration
-    INTERFACE
-        ${CMAKE_CURRENT_LIST_DIR}/codec_registration.hpp
+target_link_libraries(CodecRegistration
+    nlohmann_json::nlohmann_json
+    StackWalker
 )
 
 target_include_directories(CodecRegistration

--- a/source/codec_registration/CMakeLists.txt
+++ b/source/codec_registration/CMakeLists.txt
@@ -3,10 +3,6 @@ project(CodecRegistration)
 
 set (CMAKE_CXX_STANDARD 17)
 
-# !!! We are dependent on this so the configuration file location gets compiled in
-# !!! ideally the hosting environment would pass in this information
-add_definitions(-DFOUNDATION_CODEC_NAME=\"${Foundation_CODEC_NAME}\")
-
 # this is the one we will install
 add_library(CodecRegistration
     codec_registration.hpp
@@ -17,6 +13,13 @@ add_library(CodecRegistration
     util.cpp
     util.hpp
 )
+
+# !!! We are dependent on this so the configuration file location gets compiled in
+# !!! ideally the hosting environment would pass in this information
+if (MSVC)
+    # used so we can look up install location from code, name log files, label dialog boxes
+    target_compile_definitions(CodecRegistration PUBLIC "FOUNDATION_CODEC_NAME=\"${Foundation_CODEC_NAME}\"")
+endif (MSVC)
 
 target_link_libraries(CodecRegistration
     nlohmann_json::nlohmann_json

--- a/source/codec_registration/CMakeLists.txt
+++ b/source/codec_registration/CMakeLists.txt
@@ -12,18 +12,20 @@ add_library(CodecRegistration
     logging.hpp
     util.cpp
     util.hpp
+     $<$<PLATFORM_ID:Windows>:platform_paths_windows.cpp>
+    platform_paths.hpp
+     $<$<PLATFORM_ID:Darwin>:platform_paths_mac.mm>
 )
 
 # !!! We are dependent on this so the configuration file location gets compiled in
 # !!! ideally the hosting environment would pass in this information
-if (MSVC)
-    # used so we can look up install location from code, name log files, label dialog boxes
-    target_compile_definitions(CodecRegistration PUBLIC "FOUNDATION_CODEC_NAME=\"${Foundation_CODEC_NAME}\"")
-endif (MSVC)
+
+# used so we can look up install location from code, name log files, label dialog boxes
+target_compile_definitions(CodecRegistration PUBLIC "FOUNDATION_CODEC_NAME=\"${Foundation_CODEC_NAME}\"")
 
 target_link_libraries(CodecRegistration
     nlohmann_json::nlohmann_json
-    StackWalker
+     $<$<PLATFORM_ID:Windows>:StackWalker>
 )
 
 target_include_directories(CodecRegistration

--- a/source/codec_registration/config.cpp
+++ b/source/codec_registration/config.cpp
@@ -1,0 +1,68 @@
+#include <fstream>
+#include <iostream>
+
+#ifdef WIN32
+#include <ShlObj.h>
+#endif
+
+#include "config.hpp"
+
+const std::string kConfigFilename{"config.json"};
+
+namespace fdn
+{
+
+#ifdef WIN32
+const PathType codecPath()
+{
+    PathType path;
+    PWSTR programs;
+    HRESULT hr = SHGetKnownFolderPath(FOLDERID_ProgramFilesX64, 0, NULL, &programs);
+    if (SUCCEEDED(hr))
+    {
+        path = programs;
+        path = path / "Adobe" / "Common" / "Plug-Ins" / "7.0" / "MediaCore" / FOUNDATION_CODEC_NAME;
+        CoTaskMemFree(programs);
+        return path;
+    }
+    throw std::runtime_error("could not get program files path");
+}
+#endif
+
+static std::string defaultLoad()
+{
+    return R"({
+    })";         //!!! might put metaconfig information here - where loaded from
+                 //!!! checkout hash etc
+}
+
+static json load()
+{
+    json loaded;
+
+    try {
+#ifdef WIN32
+        auto path = codecPath() / kConfigFilename;
+#else
+        auto path = codecPath() + "/" + kConfigFilename;
+#endif
+        std::ifstream in(path);
+        if(!in.is_open())
+        {
+            throw std::runtime_error((std::string("could not open ") + path.string()).c_str());
+        }
+        in >> loaded;
+    } catch (...) {
+        loaded = json::parse(defaultLoad());
+    }
+    return loaded;
+}
+
+const json& config()
+{
+    static json theConfig(load());
+
+    return theConfig;
+}
+
+}

--- a/source/codec_registration/config.hpp
+++ b/source/codec_registration/config.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#ifdef WIN32
+// <filesystem> not available on macOS < 10.15
+#include <filesystem>
+#endif
+
+#include <nlohmann/json.hpp>
+
+// read / write configuration to a suitable location
+
+// configuration is always json information.
+
+// clients are responsible for
+//   - providing their own serialization <-> json
+//   - handling missing configuration information
+
+namespace fdn
+{
+
+using json = nlohmann::json;
+
+#ifdef WIN32
+typedef std::filesystem::path PathType;
+#else
+typedef std::string PathType;
+#endif
+
+const PathType codecPath();
+const json &config(); // singleton access
+
+}

--- a/source/codec_registration/config.hpp
+++ b/source/codec_registration/config.hpp
@@ -1,11 +1,8 @@
 #pragma once
 
-#ifdef WIN32
-// <filesystem> not available on macOS < 10.15
-#include <filesystem>
-#endif
-
 #include <nlohmann/json.hpp>
+
+#include "platform_paths.hpp"
 
 // read / write configuration to a suitable location
 
@@ -19,14 +16,6 @@ namespace fdn
 {
 
 using json = nlohmann::json;
-
-#ifdef WIN32
-typedef std::filesystem::path PathType;
-#else
-typedef std::string PathType;
-#endif
-
-const PathType codecPath();
 const json &config(); // singleton access
 
 }

--- a/source/codec_registration/config.mm
+++ b/source/codec_registration/config.mm
@@ -1,0 +1,15 @@
+#include "config.hpp"
+#include <Foundation/Foundation.h>
+
+static NSURL *getSourceDirectoryURL()
+{
+    NSBundle *bundle = [NSBundle bundleWithIdentifier:FOUNDATION_MACOSX_BUNDLE_GUI_IDENTIFIER];
+    return [bundle URLForResource:@"Presets" withExtension:nil];
+}
+
+Presets::PathType Presets::getSourceDirectoryPath()
+{
+    @autoreleasepool {
+        return [[getSourceDirectoryURL() path] cStringUsingEncoding:NSUTF8StringEncoding];
+    }
+}

--- a/source/codec_registration/logging.cpp
+++ b/source/codec_registration/logging.cpp
@@ -1,0 +1,324 @@
+#include <chrono>
+#include <fstream>
+#include <queue>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+
+#include "config.hpp"
+#include "logging.hpp"
+
+#ifdef WIN32
+#define NOMINMAX
+#include <Windows.h>
+#include "StackWalker.h"
+#else
+#include <os/log.h>
+#endif
+
+using namespace std::chrono_literals;
+using namespace std::string_literals;
+
+namespace fdn {
+
+std::mutex g_codeLocationsMutex;
+std::vector<const CodeLocation*> g_codeLocations;
+
+size_t register_CodeLocation(const CodeLocation* location)
+{
+    std::lock_guard<std::mutex> guard(g_codeLocationsMutex);
+    g_codeLocations.push_back(location);
+    return g_codeLocations.size() - 1;
+}
+
+CodeLocation::CodeLocation(const std::string& file_, size_t line_)
+    : file(file_), line(line_)
+{
+    handle = register_CodeLocation(this);
+};
+
+enum class LoggerLocationStyle : int {
+    Off = 0,
+    ShortWithThreadName = 1,
+    LongWithThreadName = 2
+};
+
+NLOHMANN_JSON_SERIALIZE_ENUM(LoggerLocationStyle, {
+    {LoggerLocationStyle::ShortWithThreadName, "shortWithThreadName"},  // first is default
+    {LoggerLocationStyle::Off, "off"},
+    {LoggerLocationStyle::LongWithThreadName, "longWithThreadName"}
+    });
+
+
+NLOHMANN_JSON_SERIALIZE_ENUM(LogMessageSeverity, {
+    {LogMessageSeverity::Info, "info"},  // first is default
+    {LogMessageSeverity::Off, "off"},
+    {LogMessageSeverity::Debug, "debug"},
+    {LogMessageSeverity::Warning, "warning"},
+    {LogMessageSeverity::Error, "completed"},
+    {LogMessageSeverity::Fatal, "fatal"}
+});
+
+class Logger
+{
+public:
+    Logger(LogMessageSeverity threshold, PathType logPath, LoggerLocationStyle style)
+        : threshold_(threshold),
+        worker_(&Logger::messageOutputLoop, this, logPath, style)
+    {
+        nameThread("main"s);
+    }
+    ~Logger()
+    {
+        close();
+    }
+
+    struct LogMessage {
+        const CodeLocation* codeLocation;
+        LogMessageSeverity severity;  // severity==NAME_THREAD means use "text" as name of threadId
+        std::string text;
+        std::thread::id threadId;
+    };
+
+    void close() {
+        if (!closed_) {
+            quit_ = true;
+            worker_.join();
+            closed_ = true;
+        }
+    }
+
+    void pushMessage(LogMessage&& logMessage)
+    {
+        LogMessage lm = std::move(logMessage);
+        auto& [_, severity, __, ___] = lm;
+
+        if (severity < threshold_ || closed_)
+            return;
+        bool wasFatal = (severity == LogMessageSeverity::Fatal);
+
+        {
+            std::lock_guard<std::mutex> guard(messagesMutex_);
+            messages_.push(std::move(lm));
+        }
+
+        if (wasFatal)
+            close();  // we make sure all output is complete, as we're in hard crash and may lose the opportunity after
+    }
+
+    void nameThread(const std::string& name)
+    {
+        pushMessage(
+            LogMessage{
+                nullptr,
+                LogMessageSeverity::NAME_THREAD,  // hack which triggers adding a name
+                name,
+                std::this_thread::get_id()
+            }
+        );
+    }
+
+    static Logger& theLogger();
+
+private:
+    std::map<std::thread::id, std::string> threadNames_;
+
+    void handleMessage(const LogMessage& message, std::ofstream &out, LoggerLocationStyle locationStyle)
+    {
+        const auto& [codeLocation, severity, text, threadId] = message;
+
+        if (severity == LogMessageSeverity::NAME_THREAD) {  // hook to set thread names
+            threadNames_.insert({ threadId, "["s + text + "]"s });
+        }
+        else
+        {
+            auto threadNameIt = threadNames_.find(threadId);
+            if (threadNameIt == threadNames_.end()) {
+                std::stringstream fakeName;
+                fakeName << "[" << threadId << "]";
+                threadNameIt = threadNames_.insert({ threadId, fakeName.str() }).first;
+            }
+
+            std::stringstream full;
+
+            const char* severitiesAsString[] = { "", "DEBUG: ", "INFO: ", "WARNING: ", "ERROR: ", "FATAL: " };
+            auto severityAsString = severitiesAsString[int(severity)];
+            switch (locationStyle) {
+            case LoggerLocationStyle::Off:
+                full << severityAsString << text;
+                break;
+            case LoggerLocationStyle::ShortWithThreadName:
+                full << std::filesystem::path(codeLocation->file).filename().string() << "(" << codeLocation->line << ") "
+                    << threadNameIt->second << " " << severityAsString << text;
+                break;
+            case LoggerLocationStyle::LongWithThreadName:
+                full << codeLocation->file << "(" << codeLocation->line << ") "
+                    << threadNameIt->second << " " << severityAsString << text;
+                break;
+            }
+            out << full.str();
+            out.flush();
+#ifdef WIN32
+            OutputDebugString(full.str().c_str());
+#else
+            os_log_debug(OS_LOG_DEFAULT, "%s error - %s", CodecRegistry::codec()->logName().c_str(), ex.what());
+#endif
+        }
+    }
+
+    void messageOutputLoop(PathType logPath, LoggerLocationStyle locationStyle)
+    {
+        PathType logFileName = logPath / (FOUNDATION_CODEC_NAME "-log.txt");
+        std::ofstream out;
+        if (logFileName != "")
+            out.open(logFileName.c_str());
+
+        while (!quit_)
+        {
+            do {
+                // try to dequeue a message
+                std::optional<LogMessage> logMessage;
+                std::unique_lock<std::mutex> lock(messagesMutex_, std::try_to_lock);
+                if (lock.owns_lock())
+                {
+                    if (!messages_.empty())
+                    {
+                        logMessage = messages_.front();
+                        messages_.pop();
+                    }
+                }
+
+                // if a message was dequeued, used it
+                if (logMessage)
+                {
+                    handleMessage(*logMessage, out, locationStyle);
+                }
+                else {
+                    break;
+                }
+            } while (true); // continue handling while we weren't blocked and got a message from the queue
+
+            std::this_thread::sleep_for(2ms);
+        }
+
+        // after quit_ flush queue as far as possible
+        {
+            // this time wait for the mutex
+            std::lock_guard<std::mutex> guard(messagesMutex_);
+            while (!messages_.empty())
+            {
+                auto logMessage = messages_.front();
+                handleMessage(logMessage, out, locationStyle);
+                messages_.pop();
+            }
+        }
+
+        out.close();
+    }
+  
+    LogMessageSeverity threshold_;
+    bool quit_{ false };
+    bool closed_{ false };
+    std::thread worker_;
+
+    mutable std::mutex messagesMutex_;
+    mutable std::queue<LogMessage> messages_;
+
+    std::thread outputThread;
+};
+
+struct LogConfiguration
+{
+    LogMessageSeverity threshold{ LogMessageSeverity::Info }; // only severity >= threshold are logged
+    PathType path{ "" };               // "" means no log
+    LoggerLocationStyle style{ LoggerLocationStyle::ShortWithThreadName };
+};
+
+void from_json(const json& j, LogConfiguration& lc) {
+    try {
+        j.at("threshold").get_to(lc.threshold);
+    }
+    catch (...)
+    {
+    }
+    try {
+        std::string s;
+        j.at("path").get_to(s);
+        lc.path = s;
+    }
+    catch (...)
+    {
+    }
+    try {
+        j.at("style").get_to(lc.style);
+    }
+    catch (...)
+    {
+    }
+}
+
+Logger& Logger::theLogger()
+{
+    static LogConfiguration configuration = [&](...) {
+        try {
+            return fdn::config().at("logging").get<LogConfiguration>();
+        }
+        catch (...)
+        {
+        }
+        return LogConfiguration();
+    }();
+    static Logger logger(configuration.threshold, configuration.path, configuration.style);
+    return logger;
+}
+
+// external entrypoint
+void logMessage(const CodeLocation& location, LogMessageSeverity severity, const std::string& msg)
+{
+    Logger::theLogger().pushMessage(
+        fdn::Logger::LogMessage{
+            &location,
+            severity,
+            msg,
+            std::this_thread::get_id()
+        }
+    );
+}
+
+void nameThread(const std::string& name)
+{
+    fdn::Logger::theLogger().nameThread(name);
+}
+
+#ifdef WIN32
+class FDNStackWalker : public StackWalker
+{
+public:
+    FDNStackWalker() : StackWalker() {}
+
+    std::stringstream ss;
+
+protected:
+    virtual void OnOutput(LPCSTR szText) {
+        ss << szText;
+        StackWalker::OnOutput(szText);
+    }
+};
+
+// The exception filter function:
+extern "C" {
+    LONG WINAPI FDNExpFilter(EXCEPTION_POINTERS* pExp, DWORD dwExpCode)
+    {
+        FDNStackWalker sw;
+        sw.ShowCallstack(GetCurrentThread(), pExp->ContextRecord);
+        FDN_FATAL("SEH exception thrown - ", sw.ss.str());
+        return EXCEPTION_EXECUTE_HANDLER;
+    }
+}
+
+#endif
+
+
+
+}  // namespace fdn

--- a/source/codec_registration/logging.hpp
+++ b/source/codec_registration/logging.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <sstream>
+#include <string>
+
+// bare-bones logger
+//   configured from global configuration setting "logging"
+//     {
+//       ...
+//       "logging": {
+//          "path": "/path/to/where/the/logfile/should/go",
+//          "threshold": "info"
+//       }
+//     }
+//
+//     message severities are
+//        "off", "debug", "info", "warning", "error", "fatal"
+//     all messages at or above threshold are logged
+//     default threshold is "info"
+//     will try to to output to a debugger, if attached
+//     will try to write to a file in the location specified in the configuration
+//     no path = no logfile
+//
+//   with no configuration
+//     will try to to output to a debugger, if attached
+//
+//   all messages go via a queue which is checked every 2ms for output
+//   this allows usage in worker threads, but means that messages might not be exactly synchronized with
+//   other systems
+//
+//   use as
+//     FDN_<log level>(things, to, output, ...);
+//   eg
+//     FDN_INFO("we are now doing this", b, "something", 17.0);
+//     FDN_INFO("we are now doing that", d);
+//
+//     FDN_DEBUG("testvar7:", testvar7);
+//     FDN_WARN("disk space seems low");
+//     FDN_ERROR("ran out of disk space");
+//     FDN_FATAL("heap corruption detected; exiting");
+//
+//   other functions
+//     FDN_NAME_THREAD("worker_thread_7");    // output this name with any messages from the current thread
+
+namespace fdn
+{
+    enum class LogMessageSeverity : int {
+        Off = 0,      // invalid / off
+        Debug = 1,    // for debugging only; usually turned off
+        Info = 2,     // informational
+        Warning = 3,  // potential cause of later error noted
+        Error = 4,    // hit bad data or operating condition, may have to stop early 
+        Fatal = 5,    // in the process of crashing, eg seg fault
+
+        NAME_THREAD = 99   // for implementation, do not use
+    };
+    struct CodeLocation {
+        CodeLocation(const std::string& file, size_t line);
+
+        std::string file;
+        size_t line;
+
+        size_t handle;  // registered into a table on construction
+    };
+    void logMessage(const CodeLocation& codeLocation, LogMessageSeverity severity, const std::string& msg);
+    void nameThread(const std::string& name);
+    void fatalError(const std::string& msg);   // null ptr read / write, segfault, div by 0, crash imminent
+}
+
+#define FDN_DEBUG(...) { static fdn::CodeLocation __FDN_CODELOCATION(__FILE__, __LINE__); FdnDebugImplTmp(__FDN_CODELOCATION, __VA_ARGS__); }
+template <typename ...Args>
+void FdnDebugImplTmp(const fdn::CodeLocation& codeLocation, Args&& ...args)
+{
+    std::ostringstream stream;
+    (stream << ... << std::forward<Args>(args)) << '\n';
+    fdn::logMessage(codeLocation, fdn::LogMessageSeverity::Debug, stream.str());
+}
+
+#define FDN_INFO(...) { static fdn::CodeLocation __FDN_CODELOCATION(__FILE__, __LINE__); FdnInfoImplTmp(__FDN_CODELOCATION, __VA_ARGS__); }
+template <typename ...Args>
+void FdnInfoImplTmp(const fdn::CodeLocation& codeLocation, Args&& ...args)
+{
+    std::ostringstream stream;
+    (stream << ... << std::forward<Args>(args)) << '\n';
+    fdn::logMessage(codeLocation, fdn::LogMessageSeverity::Info, stream.str());
+}
+
+#define FDN_WARNING(...) { static fdn::CodeLocation __FDN_CODELOCATION(__FILE__, __LINE__); FdnWarningImplTmp(__FDN_CODELOCATION, __VA_ARGS__); }
+template <typename ...Args>
+void FdnWarningImplTmp(const fdn::CodeLocation& codeLocation, Args&& ...args)
+{
+    std::ostringstream stream;
+    (stream << ... << std::forward<Args>(args)) << '\n';
+    fdn::logMessage(codeLocation, fdn::LogMessageSeverity::Warning, stream.str());
+}
+
+#define FDN_ERROR(...) { static fdn::CodeLocation __FDN_CODELOCATION(__FILE__, __LINE__); FdnErrorImplTmp(__FDN_CODELOCATION, __VA_ARGS__); }
+template <typename ...Args>
+void FdnErrorImplTmp(const fdn::CodeLocation& codeLocation, Args&& ...args)
+{
+    std::ostringstream stream;
+    (stream << ... << std::forward<Args>(args)) << '\n';
+    fdn::logMessage(codeLocation, fdn::LogMessageSeverity::Error, stream.str());
+}
+
+#define FDN_FATAL(...) { static fdn::CodeLocation __FDN_CODELOCATION(__FILE__, __LINE__); FdnFatalImplTmp(__FDN_CODELOCATION, __VA_ARGS__); }
+template <typename ...Args>
+void FdnFatalImplTmp(const fdn::CodeLocation& codeLocation, Args&& ...args)
+{
+    std::ostringstream stream;
+    (stream << ... << std::forward<Args>(args)) << '\n';
+    fdn::logMessage(codeLocation, fdn::LogMessageSeverity::Fatal, stream.str());
+}
+
+#define FDN_NAME_THREAD(name) { fdn::nameThread(name); }

--- a/source/codec_registration/platform_paths.cpp
+++ b/source/codec_registration/platform_paths.cpp
@@ -1,0 +1,22 @@
+#include <ShlObj.h>
+
+#include "platform_paths.hpp"
+
+namespace fdn {
+
+const PathType getConfigurationPath()
+{
+    PathType path;
+    PWSTR programs;
+    HRESULT hr = SHGetKnownFolderPath(FOLDERID_ProgramFilesX64, 0, NULL, &programs);
+    if (SUCCEEDED(hr))
+    {
+        path = programs;
+        path = path / "Adobe" / "Common" / "Plug-Ins" / "7.0" / "MediaCore" / FOUNDATION_CODEC_NAME;
+        CoTaskMemFree(programs);
+        return path;
+    }
+    throw std::runtime_error("could not get program files path");
+}
+
+} // namespace fdn

--- a/source/codec_registration/platform_paths.hpp
+++ b/source/codec_registration/platform_paths.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#ifdef WIN32
+// <filesystem> not available on macOS < 10.15
+#include <filesystem>
+#endif
+
+namespace fdn
+{
+
+#ifndef __APPLE__
+typedef std::filesystem::path PathType;
+#else
+// using std::filesystem::path introduces a requirement for macOS > 10.15
+// !!! revisit when support for < 10.15 is dropped
+typedef std::string PathType;
+#endif
+PathType getConfigurationPath();
+
+}

--- a/source/codec_registration/platform_paths_mac.mm
+++ b/source/codec_registration/platform_paths_mac.mm
@@ -1,0 +1,16 @@
+#include <Foundation/Foundation.h>
+
+#include "platform_paths.hpp"
+
+fdn::PathType fdn::getConfigurationPath()
+{
+    fdn::PathType path;
+    @autoreleasepool {
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
+        NSString *applicationSupportDirectory = [paths firstObject];
+        NSString *configurationPath = [NSString stringWithFormat:@"%@%@", applicationSupportDirectory, @"/CodecFoundation/"];
+        path = [[configurationPath stringByExpandingTildeInPath] cStringUsingEncoding:NSUTF8StringEncoding];
+        
+    }
+    return path;
+}

--- a/source/codec_registration/platform_paths_windows.cpp
+++ b/source/codec_registration/platform_paths_windows.cpp
@@ -1,0 +1,22 @@
+#include <ShlObj.h>
+
+#include "platform_paths.hpp"
+
+namespace fdn {
+
+const PathType getConfigurationPath()
+{
+    PathType path;
+    PWSTR programs;
+    HRESULT hr = SHGetKnownFolderPath(FOLDERID_ProgramFilesX64, 0, NULL, &programs);
+    if (SUCCEEDED(hr))
+    {
+        path = programs;
+        path = path / "Adobe" / "Common" / "Plug-Ins" / "7.0" / "MediaCore" / FOUNDATION_CODEC_NAME;
+        CoTaskMemFree(programs);
+        return path;
+    }
+    throw std::runtime_error("could not get program files path");
+}
+
+} // namespace fdn

--- a/source/codec_registration/platform_paths_windows.cpp
+++ b/source/codec_registration/platform_paths_windows.cpp
@@ -4,7 +4,7 @@
 
 namespace fdn {
 
-const PathType getConfigurationPath()
+PathType getConfigurationPath()
 {
     PathType path;
     PWSTR programs;

--- a/source/plugin/after_effects/output_module.cpp
+++ b/source/plugin/after_effects/output_module.cpp
@@ -8,9 +8,24 @@ using json = nlohmann::json;
 #include "exporter.hpp"
 #include "string_conversion.hpp"
 #include "codec_registration.hpp"
+#include "logging.hpp"
 
 #include "output_module.h"
 #include "ui.h"
+
+#define API_ERRORHANDLER_BEGIN(tmpApiName) const char *apiName = tmpApiName; FDN_DEBUG(apiName); try {
+#define API_ERRORHANDLER_END()                                       \
+    }                                                                \
+    catch (const std::exception& ex)                                 \
+    {                                                                \
+        FDN_ERROR("exception in ", apiName, ": ", ex.what());        \
+        err = A_Err_GENERIC;                                         \
+    }                                                                \
+    catch (...)                                                      \
+    {                                                                \
+        FDN_ERROR("unknown exception in ", apiName);                 \
+        err = A_Err_GENERIC;                                         \
+    }
 
 static AEGP_PluginID S_mem_id = 0;
 
@@ -18,9 +33,16 @@ static A_Err DeathHook(
     AEGP_GlobalRefcon unused1 ,
     AEGP_DeathRefcon unused2)
 {
+    FDN_INFO("AEX output plugin exit");
+
+    A_Err err = A_Err_NONE;
+    API_ERRORHANDLER_BEGIN("DeathHook");
+
     CodecRegistry::codec().reset();
 
-    return A_Err_NONE;
+    API_ERRORHANDLER_END();
+
+    return err;
 }
 
 struct OutputOptions
@@ -121,6 +143,8 @@ static MovieFile createMovieFile(const std::string &filename,
     MovieFile fileWrapper;
     auto file=std::make_shared<FILE *>((FILE *)nullptr);
     fileWrapper.onOpenForWrite = [=]() {
+        FDN_INFO("opening ", filename, " for writing");
+
 #ifdef _WIN64
         fopen_s(file.get(), filename.c_str(), "wb");
 #else
@@ -205,6 +229,9 @@ AEIO_InitOutputSpec(
     A_Boolean      *user_interacted)
 {
     A_Err       err = A_Err_NONE;
+
+    API_ERRORHANDLER_BEGIN("AEIO_InitOutputSpec");
+
     AEIO_Handle new_optionsH = NULL,
                 old_optionsH = 0;
     OutputOptions  *new_optionsP;
@@ -259,6 +286,9 @@ AEIO_InitOutputSpec(
     if (old_optionsH) {
         ERR(suites.MemorySuite1()->AEGP_FreeMemHandle(old_optionsH));
     }
+
+    API_ERRORHANDLER_END();
+
     return err;
 }
 
@@ -270,6 +300,9 @@ AEIO_GetFlatOutputOptions(
     AEIO_Handle        *new_optionsPH)
 {
     A_Err                        err                = A_Err_NONE;
+
+    API_ERRORHANDLER_BEGIN("AEIO_GetFlatOutputOptions");
+
     OutputOptions *new_optionsP;
     AEGP_SuiteHandler            suites(basic_dataP->pica_basicP);
 
@@ -298,6 +331,8 @@ AEIO_GetFlatOutputOptions(
         }
     }
 
+    API_ERRORHANDLER_END();
+
     return err;
 }
 
@@ -311,13 +346,18 @@ AEIO_DisposeOutputOptions(
     AEIO_Handle			optionsH	=	reinterpret_cast<AEIO_Handle>(optionsPV);
     OutputOptions      *optionsP    =   nullptr;
     A_Err				err			=	A_Err_NONE;
-    
+   
+    API_ERRORHANDLER_BEGIN("AEIO_DisposeOutputOptions");
+
     if (optionsH){
         ERR(suites.MemorySuite1()->AEGP_LockMemHandle(optionsH, reinterpret_cast<void**>(&optionsP)));
         optionsP->~OutputOptions();
         ERR(suites.MemorySuite1()->AEGP_UnlockMemHandle(optionsH));
         ERR(suites.MemorySuite1()->AEGP_FreeMemHandle(optionsH));
     }
+
+    API_ERRORHANDLER_END();
+
     return err;
 };
 
@@ -329,6 +369,9 @@ AEIO_UserOptionsDialog(
     A_Boolean				*user_interacted0)
 { 
     A_Err						err				= A_Err_NONE;
+
+    API_ERRORHANDLER_BEGIN("AEIO_UserOptionsDialog");
+
     AEGP_SuiteHandler			suites(basic_dataP->pica_basicP);
     {
         OutputOptionsUP optionsUP = OutputOptionsHandleWrapper::wrap(suites, outH);
@@ -356,6 +399,8 @@ AEIO_UserOptionsDialog(
         //}
     }
 
+    API_ERRORHANDLER_END();
+
     return err;
 };
 
@@ -365,7 +410,10 @@ AEIO_GetOutputInfo(
     AEIO_OutSpecH		outH,
     AEIO_Verbiage		*verbiageP)
 { 
-    A_Err err			= A_Err_NONE;
+    A_Err err = A_Err_NONE;
+
+    API_ERRORHANDLER_BEGIN("AEIO_GetOutputInfo");
+
     AEGP_SuiteHandler	suites(basic_dataP->pica_basicP);
     OutputOptionsUP optionsUP = OutputOptionsHandleWrapper::wrap(suites, outH);
 
@@ -399,6 +447,9 @@ AEIO_GetOutputInfo(
 
     suites.ANSICallbacksSuite1()->strcpy(verbiageP->sub_type,
                                           description.c_str());
+
+    API_ERRORHANDLER_END();
+
     return err;
 };
 
@@ -416,7 +467,9 @@ AEIO_OutputInfoChanged(
     */
     
     A_Err err					=	A_Err_NONE;
-    
+
+    API_ERRORHANDLER_BEGIN("AEIO_OutputInfoChanged");
+
     AEIO_AlphaLabel	alpha;
     AEFX_CLR_STRUCT(alpha);
     
@@ -446,6 +499,9 @@ AEIO_OutputInfoChanged(
         ERR(suites.IOOutSuite4()->AEGP_GetOutSpecFPS(outH, &native_fps));
         ERR(suites.IOOutSuite4()->AEGP_GetOutSpecHSF(outH, &hsf));
     }
+
+    API_ERRORHANDLER_END();
+
     return err;
 }
 
@@ -455,6 +511,10 @@ AEIO_SetOutputFile(
     AEIO_OutSpecH		outH, 
     const A_UTF16Char	*file_pathZ)
 { 
+    A_Err err = A_Err_NONE;
+    API_ERRORHANDLER_BEGIN("AEIO_SetOutputFile");
+    API_ERRORHANDLER_END();
+
     return AEIO_Err_USE_DFLT_CALLBACK;
 }
 
@@ -465,6 +525,9 @@ AEIO_StartAdding(
     A_long				flags)
 { 
     A_Err				err			=	A_Err_NONE;
+
+    API_ERRORHANDLER_BEGIN("AEIO_StartAdding");
+
     A_Time				duration	=	{0,1};
     A_short				depth		=	0;
     A_Fixed				fps			=	0;
@@ -647,7 +710,10 @@ AEIO_StartAdding(
             return A_Err_PARAMETER;  //!!! AE generally hard crashes in event of errors
         }
     }
-    return err; 
+
+    API_ERRORHANDLER_END();
+
+    return err;
 };
 
 static A_Err	
@@ -662,6 +728,9 @@ AEIO_AddFrame(
     AEIO_InterruptFuncs		*inter0)
 { 
     A_Err		err			= A_Err_NONE;
+
+    API_ERRORHANDLER_BEGIN("AEIO_AddFrame");
+
     A_Boolean	deep_worldB	= PF_WORLD_IS_DEEP(wP);
                 #ifdef AE_OS_MAC
                 #pragma unused (deep_worldB)
@@ -718,6 +787,9 @@ AEIO_AddFrame(
             return A_Err_PARAMETER;  //!!! AE generally hard crashes in event of errors
         }
     }
+
+    API_ERRORHANDLER_END();
+
     return err; 
 };
                                 
@@ -727,6 +799,10 @@ AEIO_EndAdding(
     AEIO_OutSpecH			outH, 
     A_long					flags)
 { 
+    A_Err err = A_Err_NONE;
+
+    API_ERRORHANDLER_BEGIN("AEIO_EndAdding");
+
     AEGP_SuiteHandler	suites(basic_dataP->pica_basicP);
 
     OutputOptionsUP optionsUP = OutputOptionsHandleWrapper::wrap(suites, outH);
@@ -743,8 +819,9 @@ AEIO_EndAdding(
         return A_Err_PARAMETER;   //!!! AE generally hard crashes in event of errors
     }
     
+    API_ERRORHANDLER_END();
 
-    return A_Err_NONE;
+    return err;
 };
 
 static A_Err	
@@ -755,11 +832,16 @@ AEIO_OutputFrame(
 { 
     A_Err err	=	A_Err_NONE;
 
+    API_ERRORHANDLER_BEGIN("AEIO_OutputFrame");
+
     /*
         +	Re-interpret the supplied PF_World in your own
             format, and save it out to the outH's path.
 
     */
+
+    API_ERRORHANDLER_END();
+
     return err;
 };
 
@@ -769,6 +851,10 @@ AEIO_WriteLabels(
     AEIO_OutSpecH	outH, 
     AEIO_LabelFlags	*written)
 { 
+    A_Err err = A_Err_NONE;
+    API_ERRORHANDLER_BEGIN("AEIO_WriteLabels");
+    API_ERRORHANDLER_END();
+
     return AEIO_Err_USE_DFLT_CALLBACK;
 };
 
@@ -779,6 +865,10 @@ AEIO_GetSizes(
     A_u_longlong	*free_space, 
     A_u_longlong	*file_size)
 { 
+    A_Err err = A_Err_NONE;
+    API_ERRORHANDLER_BEGIN("DeathHook");
+    API_ERRORHANDLER_END();
+
     return AEIO_Err_USE_DFLT_CALLBACK;
 };
 
@@ -787,10 +877,14 @@ AEIO_Flush(
     AEIO_BasicData	*basic_dataP,
     AEIO_OutSpecH	outH)
 { 
+    A_Err err = A_Err_NONE;
+    API_ERRORHANDLER_BEGIN("AEIO_Flush");
+    API_ERRORHANDLER_END();
+
     /*	free any temp buffers you kept around for
         writing.
     */
-    return A_Err_NONE; 
+    return err; 
 };
 
 static A_Err	
@@ -802,6 +896,9 @@ AEIO_AddSoundChunk(
     const void		*dataPV)
 {
     A_Err err		= A_Err_NONE;
+
+    API_ERRORHANDLER_BEGIN("AEIO_AddSoundChunk");
+
     AEGP_SuiteHandler	suites(basic_dataP->pica_basicP);
     OutputOptionsUP optionsUP = OutputOptionsHandleWrapper::wrap(suites, outH);
     if (!optionsUP)
@@ -824,6 +921,9 @@ AEIO_AddSoundChunk(
             num_channels * num_samplesLu * bytes_per_sample
         );
     }
+
+    API_ERRORHANDLER_END();
+
     return err; 
 };
 
@@ -832,8 +932,13 @@ AEIO_Idle(
     AEIO_BasicData			*basic_dataP,
     AEIO_ModuleSignature	sig,
     AEIO_IdleFlags			*idle_flags0)
-{ 
-    return A_Err_NONE; 
+{
+    A_Err err = A_Err_NONE;
+
+    API_ERRORHANDLER_BEGIN("AEIO_Idle");
+    API_ERRORHANDLER_END();
+
+    return err; 
 };	
 
 
@@ -843,6 +948,10 @@ AEIO_GetDepths(
     AEIO_OutSpecH			outH, 
     AEIO_SupportedDepthFlags		*which)
 { 
+    A_Err err = A_Err_NONE;
+    API_ERRORHANDLER_BEGIN("AEIO_GetDepths");
+
+
     /*	Enumerate possible output depths by OR-ing 
         together different AEIO_SupportedDepthFlags.
     */
@@ -855,7 +964,9 @@ AEIO_GetDepths(
         AEIO_SupportedDepthFlags_DEPTH_96 |  // float without alpha (?)
         AEIO_SupportedDepthFlags_DEPTH_128;  // float with alpha (?)
 
-    return A_Err_NONE; 
+    API_ERRORHANDLER_END();
+
+    return err; 
 };
 
 static A_Err	
@@ -864,7 +975,12 @@ AEIO_GetOutputSuffix(
     AEIO_OutSpecH	outH, 
     A_char			*suffix)
 { 
-    return AEIO_Err_USE_DFLT_CALLBACK;
+    A_Err err = AEIO_Err_USE_DFLT_CALLBACK;
+    API_ERRORHANDLER_BEGIN("AEIO_GetOutputSuffix");
+
+    API_ERRORHANDLER_END();
+
+    return err;
 };
 
 
@@ -876,7 +992,11 @@ AEIO_SetUserData(
     A_u_long				indexLu,
     const AEIO_Handle		dataH)
 { 
-    return A_Err_NONE; 
+    A_Err err = A_Err_NONE;
+    API_ERRORHANDLER_BEGIN("AEIO_SetUserData");
+    API_ERRORHANDLER_END();
+
+    return err;
 };
 
 static A_Err
@@ -885,7 +1005,6 @@ ConstructModuleInfo(
     AEIO_ModuleInfo		*info)
 {
     A_Err err = A_Err_NONE;
-
     AEGP_SuiteHandler	suites(pica_basicP);
 
     const auto& codec = *CodecRegistry::codec();
@@ -972,6 +1091,8 @@ EntryPointFunc(
     AEGP_GlobalRefcon		*global_refconP)		/* << */
 {
     A_Err 				err					= A_Err_NONE;
+    API_ERRORHANDLER_BEGIN("EntryPointFunc");
+
     AEIO_ModuleInfo		info;
     AEIO_FunctionBlock4	funcs;
     AEGP_SuiteHandler	suites(pica_basicP);	
@@ -991,5 +1112,8 @@ EntryPointFunc(
     ERR(suites.UtilitySuite3()->AEGP_RegisterWithAEGP(	NULL,
                                                        "NotchLC",
                                                        &S_mem_id));
+
+    API_ERRORHANDLER_END();
+
     return err;
 }

--- a/source/plugin/after_effects/win/output_module.rc
+++ b/source/plugin/after_effects/win/output_module.rc
@@ -83,7 +83,7 @@ BEGIN
         BEGIN
             VALUE "Comments", "\0"
             VALUE "CompanyName", "10BitFx\0"  // NOTCHLC SPECIFIC
-            VALUE "FileDescription", "AfterEffects output module to export " CODEC_NAME "\0"
+            VALUE "FileDescription", "AfterEffects output module to export " FOUNDATION_CODEC_NAME "\0"
             VALUE "FileVersion", "1, 0, 0, 1\0"
             VALUE "InternalName", AEX_INTERNAL_NAME
             VALUE "LegalCopyright", "Copyright � 2019\0"

--- a/source/plugin/after_effects/win/resource.h
+++ b/source/plugin/after_effects/win/resource.h
@@ -26,9 +26,9 @@
 #define AEX_ORIGINAL_FILENAME "AEXPlugin.aex\0"
 #define AEX_PRODUCT_NAME "AEXPlugin\0"
 #else
-#define OPTIONS_CAPTION_NAME CODEC_NAME##" Options"
-#define AEX_FILE_DESCRIPTION "AfterEffects output module to export "##CODEC_NAME##"\0"
-#define AEX_INTERNAL_NAME CODEC_NAME##"AfterEffectsPlugin\0"
-#define AEX_ORIGINAL_FILENAME CODEC_NAME##"AEXPlugin.aex\0"
-#define AEX_PRODUCT_NAME CODEC_NAME##"\0"
+#define OPTIONS_CAPTION_NAME FOUNDATION_CODEC_NAME##" Options"
+#define AEX_FILE_DESCRIPTION "AfterEffects output module to export "##FOUNDATION_CODEC_NAME##"\0"
+#define AEX_INTERNAL_NAME FOUNDATION_CODEC_NAME##"AfterEffectsPlugin\0"
+#define AEX_ORIGINAL_FILENAME FOUNDATION_CODEC_NAME##"AEXPlugin.aex\0"
+#define AEX_PRODUCT_NAME FOUNDATION_CODEC_NAME##"\0"
 #endif

--- a/source/plugin/premiere/CMakeLists.txt
+++ b/source/plugin/premiere/CMakeLists.txt
@@ -44,6 +44,7 @@ if (MSVC)
             OUTPUT_NAME "${Foundation_CODEC_NAME}Plugin"
             SUFFIX ".prm"
     )
+    install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}> DESTINATION bin OPTIONAL)
 elseif (APPLE)
 # macOS plugins have a common extension, so identify the host in the name
     set_target_properties(PremierePlugin

--- a/source/plugin/premiere/CMakeLists.txt
+++ b/source/plugin/premiere/CMakeLists.txt
@@ -91,13 +91,6 @@ if (APPLE)
                     PROPERTY COMPILE_DEFINITIONS FOUNDATION_MACOSX_BUNDLE_GUI_IDENTIFIER=@\"${Foundation_IDENTIFIER_PREFIX}.pr\"
     )
 endif (APPLE)
-if (MSVC)
-    # used so we can look up install location from code
-    set_property(SOURCE presets.cpp
-                    APPEND
-                    PROPERTY COMPILE_DEFINITIONS FOUNDATION_CODEC_NAME=\"${Foundation_CODEC_NAME}\"
-    )
-endif (MSVC)
 install(
   TARGETS PremierePlugin
   RUNTIME

--- a/source/plugin/premiere/async_importer.cpp
+++ b/source/plugin/premiere/async_importer.cpp
@@ -1,16 +1,22 @@
 #include "async_importer.hpp"
+#include "logging.hpp"
 
 PREMPLUGENTRY xAsyncImportEntry(
     int		inSelector,
     void	*inParam)
 {
+    FDN_DEBUG("xAsyncImportEntry selector=", inSelector);
+
     csSDK_int32			result = aiUnsupported;
+
+    try {
     AsyncImporter	   *asyncImporter = 0;
 
     switch (inSelector)
     {
     case aiInitiateAsyncRead:
     {
+        FDN_DEBUG("aiInitiateAsyncRead");
         aiAsyncRequest* asyncRequest(reinterpret_cast<aiAsyncRequest*>(inParam));
         asyncImporter = reinterpret_cast<AsyncImporter*>(asyncRequest->inPrivateData);
         result = asyncImporter->OnInitiateAsyncRead(asyncRequest->inSourceRec);
@@ -18,17 +24,20 @@ PREMPLUGENTRY xAsyncImportEntry(
     }
     case aiCancelAsyncRead:
     {
+        FDN_DEBUG("aiCancelAsyncRead");
         return aiUnsupported;
         break;
     }
     case aiFlush:
     {
+        FDN_DEBUG("aiFlush");
         asyncImporter = reinterpret_cast<AsyncImporter*>(inParam);
         result = asyncImporter->OnFlush();
         break;
     }
     case aiGetFrame:
     {
+        FDN_DEBUG("aiGetFrame");
         imSourceVideoRec* getFrameRec(reinterpret_cast<imSourceVideoRec*>(inParam));
         asyncImporter = reinterpret_cast<AsyncImporter*>(getFrameRec->inPrivateData);
         result = asyncImporter->OnGetFrame(getFrameRec);
@@ -36,11 +45,23 @@ PREMPLUGENTRY xAsyncImportEntry(
     }
     case aiClose:
     {
+        FDN_DEBUG("aiClose");
         asyncImporter = reinterpret_cast<AsyncImporter*>(inParam);
         delete asyncImporter;
         result = aiNoError;
         break;
     }
+    }
+    }
+    catch (const std::exception& ex)
+    {
+        FDN_ERROR("async import exception: ", ex.what());
+        result = aiUnknownError;
+    }
+    catch (...)
+    {
+        FDN_ERROR("async import unknown exception");
+        result = aiUnknownError;
     }
 
     return result;

--- a/source/plugin/premiere/main.cpp
+++ b/source/plugin/premiere/main.cpp
@@ -462,7 +462,7 @@ static MovieFile createMovieFile(PrSDKExportFileSuite* exportFileSuite, csSDK_in
         //--- this error flag may be overwritten fairly deeply in callbacks so original error may be
         //--- passed up to Adobe
         csSDK_int32 outPathLength{ 255 };
-        wchar_t     outputFilePath[256] = { '\0' };
+        prUTF16Char outputFilePath[256] = { '\0' };
         exportFileSuite->GetPlatformPath(fileObject, &outPathLength, outputFilePath);
         FDN_INFO("opening ", SDKStringConvert::to_string(outputFilePath), " for writing");
 

--- a/source/session/exporter.cpp
+++ b/source/session/exporter.cpp
@@ -388,7 +388,7 @@ void Exporter::dispatchVideo(int64_t iFrame, const uint8_t* data, size_t stride,
     auto start = std::chrono::high_resolution_clock::now();
     static_cast<VideoExportJob&>(*job).codecJob->copyExternalToLocal(data, stride, format);
     auto end = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double, std::milli> durationInMs = endWait - startWait;
+    std::chrono::duration<double, std::milli> durationInMs = end - start;
     FDN_DEBUG(job->name, " queuing took ", durationInMs.count(), "ms");
 
     jobEncoder_.push(std::move(job));

--- a/source/session/exporter.hpp
+++ b/source/session/exporter.hpp
@@ -25,6 +25,8 @@ struct ExportJobBase
     virtual ExportJobType type() const { throw std::runtime_error("no type"); }
     virtual void encode() { }; // readies output 
 
+    std::string name;           // for debugging
+
     int64_t iFrameOrPts{ -1 };  // for video jobs
     EncodeOutput output;
 
@@ -114,10 +116,11 @@ class ExporterWorker
 public:
     ExporterWorker(
         std::atomic<bool>& error,
-        ExporterJobEncoder& encoder, ExporterJobWriter& writer);
+        ExporterJobEncoder& encoder, ExporterJobWriter& writer,
+        const std::string& name);
     ~ExporterWorker();
 
-    static void worker_start(ExporterWorker& worker);
+     void worker_start();
 
 private:
     std::thread worker_;
@@ -127,6 +130,8 @@ private:
     std::atomic<bool>& error_;
     ExporterJobEncoder& jobEncoder_;
     ExporterJobWriter& jobWriter_;
+
+    std::string name_;
 };
 
 


### PR DESCRIPTION
Plugins are now configured via ```config.json``` which may be placed alongside the plugins in C:\Program Files\Adobe\Common\Plug-ins\7.0\MediaCore\<codec name>

Format is
```
 {
    "logging": {
        "threshold": "debug",
        "path": "c:\\Users\\<username>\\Desktop"
    },
    "exporter": {
       "initialWorkers": 1,
       "maxWorkers": -1
    }
}
```

Logging functionality has been added, including access macros.
```
// bare-bones logger
//   configured from global configuration setting "logging"
//     {
//       ...
//       "logging": {
//          "path": "/path/to/where/the/logfile/should/go",
//          "threshold": "info"
//       }
//     }
//
//     message severities are
//        "off", "debug", "info", "warning", "error", "fatal"
//     all messages at or above threshold are logged
//     default threshold is "info"
//     will try to to output to a debugger, if attached
//     will try to write to a file in the location specified in the configuration
//     no path = no logfile
//
//   with no configuration
//     will try to to output to a debugger, if attached
//
//   all messages go via a queue which is checked every 2ms for output
//   this allows usage in worker threads, but means that messages might not be exactly synchronized with
//   other systems
//
//   use as
//     FDN_<log level>(things, to, output, ...);
//   eg
//     FDN_INFO("we are now doing this", b, "something", 17.0);
//     FDN_INFO("we are now doing that", d);
//
//     FDN_DEBUG("testvar7:", testvar7);
//     FDN_WARN("disk space seems low");
//     FDN_ERROR("ran out of disk space");
//     FDN_FATAL("heap corruption detected; exiting");
//
//   other functions
```

Exporter functionality from AME / Premiere is also wrapped in SEH on Windows, meaning it can trap segfaults / div-by-0 etc. A stacktrace feature is implemented such that the line the error occurred on is detailed. Note: this requires .pdb files to be present on the system; they are built by ReleaseWithDebugInfo but not incorporated into the installer.

Many pieces of logging have been added.

Todo:
 - get it working on MacOs [config file location, default log output, stack trace]


